### PR TITLE
解决后端使用simple-json 和 simple-array列类型时前端无法创建eps的问题

### DIFF
--- a/build/cool/lib/eps/config.ts
+++ b/build/cool/lib/eps/config.ts
@@ -12,7 +12,11 @@ export default {
 			},
 			{
 				type: "string",
-				test: ["varchar", "text"],
+				test: ["varchar", "text","simple-json"]
+			},
+			{
+				type: "string[]",
+				test: ["simple-array"]
 			},
 			{
 				type: "Date",


### PR DESCRIPTION
后端使用此两个类型后，创建eps.d.ts会把这两个类型直接指定为成员类型，但是由于该两种类型并未ts原生类型。所以前端创建eps总是失败，导致一系列问题。