### PR TITLE
修复后端typeorm使用simple-array或simple-json类型前端错误

### DIFF
--- a/build/cool/lib/eps/config.ts
+++ b/build/cool/lib/eps/config.ts
@@ -12,7 +12,11 @@ export default {
 			},
 			{
 				type: "string",
-				test: ["varchar", "text"],
+				test: ["varchar", "text", "simple-json"]
+			},
+			{
+				type: "string[]",
+				test: ["simple-array"]
 			},
 			{
 				type: "Date",


### PR DESCRIPTION
前端获取eps时无法解析此两种类型，导致从__cool_eps获取数据生成前端的eps文件失败的问题